### PR TITLE
Minor changes

### DIFF
--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -77,15 +77,12 @@ pub fn create_game(lobby: &Lobby, players: &mut HashMap<PlayerID, Player>) -> (G
             systems: generate_systems()
         }
     };
-    lobby.players.iter().for_each(|pid| players
-        .get_mut(&pid)
-        .ok_or(InternalError::PlayerUnknown)
-        .and_then(|p| {
+    for pid in &lobby.players {
+        players.get_mut(pid).map(|p| {
             p.data.lobby = None;
-            p.data.game = Some(game.data.id.clone());
-            game.players.insert(p.data.id.clone(), p.clone());
-            return Ok(())
-        }).unwrap()
-    );
+            p.data.game = Some(game.data.id);
+            game.players.insert(p.data.id, p.clone())
+        });
+    }
     (game.data.id.clone(), game.start())
 }

--- a/src/lib/auth.rs
+++ b/src/lib/auth.rs
@@ -8,6 +8,8 @@ use std::default::Default;
 
 const JWT_SECRET: & 'static [u8] = b"secret";
 
+/// This structure represent an HTTP authentication token.
+/// Every route with a `Claim` in its parameters will only allow authentified requests.
 #[derive(Serialize, Deserialize)]
 pub struct Claims {
     pub pid:PlayerID,

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -62,18 +62,19 @@ impl ResponseError for ServerError {
     }
 }
 
+/// This enum represent all kinds of errors this specific server can encounter.
 #[derive(Debug)]
 pub enum InternalError {
-    // A player tried to perform a restricted operation
+    /// A player tried to perform a restricted operation
     AccessDenied,
-    // We couldn't map a PlayerID to an existing player
+    /// We couldn't map a PlayerID to an existing player
     PlayerUnknown,
-    // We couldn't map a LobbyID to an existing Lobby
+    /// We couldn't map a LobbyID to an existing Lobby
     LobbyUnknown,
-    // A player already in a lobby tries to create a lobby
+    /// A player already in a lobby tries to create a lobby
     AlreadyInLobby,
-    // A player wants to modify a lobby its not in
+    /// A player wants to modify a lobby its not in
     NotInLobby,
-    // A Claims was requested by the route but none were given
+    /// A Claims was requested by the route but none were given
     NoAuthorizationGiven,
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,4 +1,7 @@
 pub mod auth;
 pub mod error;
 
+/// Helper type used as a return type for HTTP handler.
+/// This type helps agregating multiple error types from this crate as well as different external
+/// crates which have an error system.
 pub type Result<T> = std::result::Result<T, error::ServerError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+///! This crate is the 
 #![feature(concat_idents)]
 use actix_web::{web, App, HttpServer};
 use actix_web::middleware::Logger;
@@ -33,10 +34,10 @@ pub struct AppState {
 macro_rules! res_access {
     { $name:ident , $name_mut:ident : $t:ty } => {
         pub fn $name(&self) -> std::sync::RwLockReadGuard<$t> {
-            self.$name.read().expect(concat!("AppState::", stringify!($name), "() RwLock poisoned"))
+            self.$name.read().expect(stringify!("AppState::", $name, "() RwLock poisoned"))
         } 
         pub fn $name_mut(&self) -> std::sync::RwLockWriteGuard<$t> {
-            self.$name.write().expect(concat!("AppState::", stringify!($name_mut), " RwLock poisoned"))
+            self.$name.write().expect(stringify!("AppState::", $name_mut, "() RwLock poisoned"))
         } 
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-///! This crate is the 
-#![feature(concat_idents)]
 use actix_web::{web, App, HttpServer};
 use actix_web::middleware::Logger;
 use game::lobby;
@@ -9,7 +7,6 @@ use std::collections::HashMap;
 use std::clone::Clone;
 use std::sync::RwLock;
 use std::env;
-use std::concat_idents;
 use env_logger;
 #[cfg(feature="ssl-secure")]
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
@@ -24,6 +21,8 @@ use game::{
     lobby::{Lobby, LobbyID},
 };
 
+/// Global state of the game, containing everything we need to access from everywhere.
+/// Each attribute is between a [`RwLock`](https://doc.rust-lang.org/std/sync/struct.RwLock.html)
 pub struct AppState {
     factions: RwLock<HashMap<FactionID, Faction>>,
     games: RwLock<HashMap<GameID, actix::Addr<Game>>>,

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -14,7 +14,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// How long before lack of client response causes a timeout
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Entry point for our route
+/// Entry point for our the WebSocket handshake
 pub async fn entrypoint(
     req: HttpRequest,
     stream: web::Payload,
@@ -45,6 +45,7 @@ pub async fn entrypoint(
     Ok(resp)
 }
 
+/// WebSocket actor used to communicate with a player.
 pub struct ClientSession {
     hb: Instant,
     state: web::Data<AppState>,

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -21,7 +21,7 @@ pub async fn entrypoint(
     state: web::Data<AppState>,
     claims: Claims,
 ) -> Result<HttpResponse> {
-    let mut players = state.players.write().unwrap();
+    let mut players = state.players_mut();
     let p = players.get_mut(&claims.pid);
 
     if p.is_none() {
@@ -53,7 +53,7 @@ pub struct ClientSession {
 
 impl ClientSession {
     fn logout(&self) {
-        let mut players = self.state.players.write().expect("Players RwLock poisoned");
+        let mut players = self.state.players_mut();
         let data = players.get(&self.pid).unwrap().data.clone();
         players.remove(&self.pid);
 

--- a/src/ws/protocol.rs
+++ b/src/ws/protocol.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+/// Tokens representing the type of WS message sent to notify a player.
 #[derive(Serialize, Clone)]
 pub enum Action {
     GameStarted,
@@ -15,6 +16,9 @@ pub enum Action {
     PlayerDisconnected
 }
 
+/// This structure is generic over `T` to allow us to freely change the `T` sent for each message.
+/// As long as `T` is `Serialize`, we can send whatever we want. It is up to the client to handle
+/// the deserialization given the documented structure of the data sent.
 #[derive(actix::Message, Serialize, Clone)]
 #[rtype(result = "()")]
 pub struct Message<T> {


### PR DESCRIPTION
Add comments on datastructures and modify the way we access to the global state.
Instead of directly using the `RwLock` attributes of `AppData`, we now access them using functions named:

`<attribute-name>()` for Read
`<attribute-name>_mut()` for Write

Examples can be found in `src/game/lobby.rs` file.
This allows us to control the logic behind data access without breaking the code using data.
If we want to change the `RwLock` to a `Mutex` or whatever, we can totaly change it and it will remain a totaly transparent reference or mutable reference to the accessed data.