### PR TITLE
Fix/even battles

### DIFF
--- a/migrations/20210704180730_Initial_Migration_with_current_database_state.sql
+++ b/migrations/20210704180730_Initial_Migration_with_current_database_state.sql
@@ -91,7 +91,8 @@ CREATE TABLE IF NOT EXISTS fleet__squadrons(
     fleet_id UUID NOT NULL,
     category VARCHAR(25) NOT NULL,
     formation VARCHAR(10) NOT NULL,
-    quantity INT NOT NULL
+    quantity INT NOT NULL,
+    damage INT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS system__ship_queues(
     id UUID PRIMARY KEY,

--- a/migrations/20210905010046_Player_Rankings.sql
+++ b/migrations/20210905010046_Player_Rankings.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS player__rankings(
     player_id UUID NOT NULL,
     destroyed_ships JSONB NOT NULL,
     destroyed_ships_score INT NOT NULL,
+    lost_ships JSONB NOT NULL,
     lost_ships_score INT NOT NULL,
     successful_conquests INT NOT NULL,
     lost_systems INT NOT NULL

--- a/src/game/fleet/combat/battle.rs
+++ b/src/game/fleet/combat/battle.rs
@@ -192,7 +192,7 @@ impl Battle {
     }
 
     pub async fn engage(arriver: &Fleet, orbiting_fleets: &HashMap<FleetID, Fleet>, system: &System, defender_faction: Option<FactionID>, server: &GameServer) -> Result<()> {
-        Conquest::stop(&system, &server).await?;
+        Conquest::stop(&system, &server, false).await?;
         
         let mut fleets = orbiting_fleets.clone();
         fleets.insert(arriver.id.clone(), arriver.clone());
@@ -256,14 +256,14 @@ impl Battle {
 
         // If all the fleets are destroyed, in every case a current conquest would be stopped
         if self.victor.is_none() {
-            return Conquest::stop(&system, &server).await;
+            return Conquest::stop(&system, &server, true).await;
         }
         // If the victor is from the same faction as the system's owner, conquest ceases
         if let Some(owner) = system.player {
             let owner_player = Player::find(owner, &server.state.db_pool).await?;
 
             if owner_player.faction == self.victor {
-                return Conquest::stop(&system, &server).await;
+                return Conquest::stop(&system, &server, true).await;
             }
         }
 

--- a/src/game/fleet/combat/battle.rs
+++ b/src/game/fleet/combat/battle.rs
@@ -180,15 +180,15 @@ impl Battle {
             .collect()
     }
 
-    fn process_victor(&self) -> Result<FactionID> {
+    fn process_victor(&self) -> Option<FactionID> {
         for (fid, fleets) in &self.fleets {
             for fleet in fleets.values() {
                 if fleet.squadrons.iter().any(|s| s.quantity > 0) {
-                    return Ok(*fid);
+                    return Some(*fid);
                 }
             }
         }
-        Err(InternalError::NotFound.into())
+        None
     }
 
     pub async fn engage(arriver: &Fleet, orbiting_fleets: &HashMap<FleetID, Fleet>, system: &System, defender_faction: Option<FactionID>, server: &GameServer) -> Result<()> {
@@ -225,7 +225,7 @@ impl Battle {
     }
 
     pub async fn end(&mut self, server: &GameServer) -> Result<()> {
-        self.victor = Some(self.process_victor()?);
+        self.victor = self.process_victor();
         self.ended_at = Some(Time::now());
         self.update(&mut &server.state.db_pool).await?;
         
@@ -237,24 +237,37 @@ impl Battle {
 
         let fleet = Fleet::find(&self.attacker, &server.state.db_pool).await?;
         let system = System::find(self.system, &server.state.db_pool).await?;
+        let mut log_data = vec![
+            ("battle_id", self.id.0.to_string()),
+            ("system_id", self.system.0.to_string())
+        ];
+
+        if let Some(victor) = self.victor {
+            log_data.push(("victor_id", victor.0.to_string()));
+        }
 
         log(
             gelf::Level::Informational,
             "Battle ended",
             &format!("The battle on {} is over", system.to_log_message()),
-            vec![
-                ("battle_id", self.id.0.to_string()),
-                ("victor_id", self.victor.unwrap().0.to_string()),
-                ("system_id", self.system.0.to_string())
-            ],
+            log_data,
             &server.state.logger
         );
 
-        if self.victor == self.defender_faction {
-            return Ok(());
+        // If all the fleets are destroyed, in every case a current conquest would be stopped
+        if self.victor.is_none() {
+            return Conquest::stop(&system, &server).await;
+        }
+        // If the victor is from the same faction as the system's owner, conquest ceases
+        if let Some(owner) = system.player {
+            let owner_player = Player::find(owner, &server.state.db_pool).await?;
+
+            if owner_player.faction == self.victor {
+                return Conquest::stop(&system, &server).await;
+            }
         }
 
-        Conquest::resume(&fleet, &system, self.victor, &server).await
+        return Conquest::resume(&fleet, &system, self.victor, &server).await;
     }
 }
 

--- a/src/game/fleet/combat/conquest.rs
+++ b/src/game/fleet/combat/conquest.rs
@@ -358,7 +358,6 @@ impl Conquest {
     }
 }
 
-    
 fn get_conquest_time(fleets: &Vec<&Fleet>, percent: f32, game_speed: GameOptionSpeed) -> f64 {
     let mut strength = 0;
 
@@ -390,7 +389,7 @@ mod tests
     #[test]
     fn test_get_conquest_time() {
         let mut fleet = get_fleet_mock();
-        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter));
+        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter, 0));
         let fleets = vec![&fleet];
         let game_speed = GameOptionSpeed::Medium;
 
@@ -400,7 +399,7 @@ mod tests
     #[test]
     fn test_get_conquest_time_in_fast_mode() {
         let mut fleet = get_fleet_mock();
-        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter));
+        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter, 0));
         let fleets = vec![&fleet];
         let game_speed = GameOptionSpeed::Fast;
 
@@ -410,7 +409,7 @@ mod tests
     #[test]
     fn test_get_conquest_time_with_percent() {
         let mut fleet = get_fleet_mock();
-        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter));
+        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter, 0));
         let fleets = vec![&fleet];
         let game_speed = GameOptionSpeed::Medium;
 
@@ -420,7 +419,7 @@ mod tests
     #[test]
     fn test_get_conquest_min_time() {
         let mut fleet = get_fleet_mock();
-        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Cruiser));
+        fleet.squadrons.push(get_squadron_mock(100, ShipModelCategory::Cruiser, 0));
         let fleets = vec![&fleet];
         let game_speed = GameOptionSpeed::Medium;
 
@@ -430,10 +429,10 @@ mod tests
     #[test]
     fn test_get_conquest_time_with_multiple_fleets() {
         let mut fleet1 = get_fleet_mock();
-        fleet1.squadrons.push(get_squadron_mock(50, ShipModelCategory::Fighter));
-        fleet1.squadrons.push(get_squadron_mock(50, ShipModelCategory::Fighter));
+        fleet1.squadrons.push(get_squadron_mock(50, ShipModelCategory::Fighter, 0));
+        fleet1.squadrons.push(get_squadron_mock(50, ShipModelCategory::Fighter, 0));
         let mut fleet2 = get_fleet_mock();
-        fleet2.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter));
+        fleet2.squadrons.push(get_squadron_mock(100, ShipModelCategory::Fighter, 0));
         let fleets = vec![&fleet1, &fleet2];
         let game_speed = GameOptionSpeed::Medium;
 
@@ -452,13 +451,14 @@ mod tests
         }
     }
 
-    fn get_squadron_mock(quantity: u16, category: ShipModelCategory) -> FleetSquadron {
+    fn get_squadron_mock(quantity: u16, category: ShipModelCategory, damage: u16) -> FleetSquadron {
         FleetSquadron{
             id: FleetSquadronID(Uuid::new_v4()),
             fleet: FleetID(Uuid::new_v4()),
             formation: FleetFormation::Center,
             quantity,
             category,
+            damage,
         }
     }
 }

--- a/src/game/fleet/fleet.rs
+++ b/src/game/fleet/fleet.rs
@@ -335,6 +335,7 @@ mod tests {
                     formation: FleetFormation::Center,
                     category: ShipModelCategory::Fighter,
                     quantity: 1,
+                    damage: 0,
                 }
             ],
             is_destroyed: false,


### PR DESCRIPTION
Une bataille pouvait se dérouler sans fin si les forces en présence n'infligeaient plus suffisamment de dommages pour détruire les vaisseaux adverses.

Le correctif s'est fait en deux étapes :

* Créer une persistence des dommages infligés aux vaisseaux d'un tour à un autre lors d'un combat. Les vaisseaux finissent donc par se détruire au fil des dommages.
* Gérer le cas des matchs nuls entre flottes, où toutes les flottes sont détruites au dernier round. Dans ce cas, toutes les conquêtes en cours sont annulées.